### PR TITLE
[#19] fix LexxPlussImportPlugin's link

### DIFF
--- a/LexxPlussImporter/build.xml
+++ b/LexxPlussImporter/build.xml
@@ -6,7 +6,7 @@
     <!-- enter the *lowest* JOSM version this plugin is currently compatible with -->
     <property name="plugin.main.version" value="14384"/>
 
-    <property name="plugin.version" value="1.1.0"/>
+    <property name="plugin.version" value="1.1.1"/>
 
     <!-- Configure these properties (replace "..." accordingly).
          See https://josm.openstreetmap.de/wiki/DevelopersGuide/DevelopingPlugins
@@ -16,7 +16,7 @@
     <property name="plugin.class" value="org.openstreetmap.josm.plugins.lexxpluss.LexxPlussImportPlugin"/>
     <property name="plugin.description" value="Import OSM data with adding lonlat coordinates"/>
     <!--<property name="plugin.icon" value="..."/>-->
-    <property name="plugin.link" value="https://github.com/LexxPluss/JOSMPlugin/LexxPlussImportPlugin"/>
+    <property name="plugin.link" value="https://wiki.openstreetmap.org/wiki/JOSM/Plugins/lexxpluss"/>
     <!--<property name="plugin.early" value="..."/>-->
     <!--<property name="plugin.requires" value="..."/>-->
     <!--<property name="plugin.stage" value="..."/>-->
@@ -29,5 +29,5 @@
     ** compile - complies the source tree
     **********************************************************
     -->
-  
+
 </project>


### PR DESCRIPTION
Fix #19 

A non-existent page was being specified in plugin.link, causing a 404 error.
The link destination was changed to the same URL as that of LexxPlussExporter. Also, since there was no URL page, a simple URL page was created.
https://wiki.openstreetmap.org/wiki/JOSM/Plugins/lexxpluss