### PR TITLE
feat: Add CSV capture actions

### DIFF
--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVAMRGoalCaptureAction.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVAMRGoalCaptureAction.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ * License: GPL. For details, see LICENSE file.
+ */
+
+package org.openstreetmap.josm.plugins.lexxpluss;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.openstreetmap.josm.actions.JosmAction;
+import org.openstreetmap.josm.command.AddCommand;
+import org.openstreetmap.josm.command.Command;
+import org.openstreetmap.josm.command.SequenceCommand;
+import org.openstreetmap.josm.data.UndoRedoHandler;
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.gui.util.GuiHelper;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * Action for capturing AMR goal from CSV file.
+ */
+public class CSVAMRGoalCaptureAction extends JosmAction {
+
+    /**
+     * Constructs a new {@code CSVAMRGoalCaptureAction}.
+     */
+    public CSVAMRGoalCaptureAction() {
+        super("Capture AMR Goal", "mapmode/amrgoalaction", "Capture AMR Goal",
+                null, false);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        var transformer = new PointTransformer();
+        var ds = getLayerManager().getEditDataSet();
+        if (!transformer.setupFromDataSet(ds))
+            return;
+        var dialog = new CSVFileDialog();
+        var ret = dialog.showOpenDialog(MainApplication.getMainFrame());
+        if (ret == CSVFileDialog.APPROVE_OPTION) {
+            var file = dialog.getSelectedFile();
+            var data = loadCSVFile(file);
+            if (!data.isEmpty()) {
+                var max = ToolsPlugin.getMaxId(ds.getWays(), "goal_id");
+                var cmds = new LinkedList<Command>();
+                for (var d : data) {
+                    var ne0 = transformer.imageXYtoEastNorth(d.x, d.y);
+                    var ne1 = ne0.add(2.8 * Math.cos(d.angle), -2.8 * Math.sin(d.angle));
+                    var nodes = new Node[]{
+                        new Node(ne0),
+                        new Node(ne1)
+                    };
+                    nodes[0].put("X_image", String.valueOf(d.x));
+                    nodes[0].put("Y_image", String.valueOf(d.y));
+                    var way = new Way();
+                    way.addNode(nodes[0]);
+                    way.addNode(nodes[1]);
+                    way.put("line_info", "goal_pose");
+                    way.put("goal_id", Integer.toString(++max));
+                    cmds.add(new AddCommand(ds, nodes[0]));
+                    cmds.add(new AddCommand(ds, nodes[1]));
+                    cmds.add(new AddCommand(ds, way));
+                }
+                UndoRedoHandler.getInstance().add(new SequenceCommand("Capture AMR Goal", cmds));
+            }
+        }
+    }
+
+    @Override
+    protected void updateEnabledState() {
+        var ds = getLayerManager().getEditDataSet();
+        setEnabled(ds != null && PointTransformer.hasTransformMatrix(ds));
+    }
+
+    /**
+     * Loads the CSV file.
+     * @param file the file
+     * @return the collection of CSV data
+     */
+    private Collection<AMRGoalData> loadCSVFile(File file) {
+        var path = file.toPath();
+        var data = new ArrayList<AMRGoalData>();
+        try {
+            var lines = Files.readAllLines(path);
+            lines.remove(0);
+            lines.forEach(line -> {
+                var parts = line.split(",");
+                if (parts.length >= 3) {
+                    var d = new AMRGoalData();
+                    d.x = Double.parseDouble(parts[0]);
+                    d.y = Double.parseDouble(parts[1]);
+                    d.angle = Double.parseDouble(parts[2]);
+                    data.add(d);
+                }
+            });
+        } catch (Exception ex) {
+            var notification = new Notification("Error reading CSV file.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+        }
+        if (data.isEmpty()) {
+            var notification = new Notification("No data found.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+        }
+        return data;
+    }
+
+    /**
+     * CSV data for AMR goal.
+     */
+    private static class AMRGoalData {
+
+        /**
+         * The x-coordinate.
+         */
+        double x;
+
+        /**
+         * The y-coordinate.
+         */
+        double y;
+
+        /**
+         * The angle.
+         */
+        double angle;
+
+        /**
+         * Constructs a new {@code AMRGoalData}.
+         */
+        AMRGoalData() {
+            x = 0.0;
+            y = 0.0;
+            angle = 0.0;
+        }
+    }
+}

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVFileDialog.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVFileDialog.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ * License: GPL. For details, see LICENSE file.
+ */
+
+package org.openstreetmap.josm.plugins.lexxpluss;
+
+import java.awt.Component;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+/**
+ * File dialog for CSV files.
+ */
+public class CSVFileDialog extends JFileChooser {
+
+    /**
+     * The current directory.
+     */
+    private static File currentDirectory = null;
+
+    /**
+     * Constructs a new {@code CSVFileDialog}.
+     */
+    public CSVFileDialog() {
+        super();
+        if (currentDirectory != null)
+            setCurrentDirectory(currentDirectory);
+        setFileSelectionMode(JFileChooser.FILES_ONLY);
+        setFileFilter(new FileNameExtensionFilter("CSV file", "csv"));
+    }
+
+    @Override
+    public int showOpenDialog(Component parent) {
+        int ret = super.showOpenDialog(parent);
+        currentDirectory = getCurrentDirectory();
+        return ret;
+    }
+}

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVPGVTapeCaptureAction.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CSVPGVTapeCaptureAction.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ * License: GPL. For details, see LICENSE file.
+ */
+
+package org.openstreetmap.josm.plugins.lexxpluss;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import org.openstreetmap.josm.actions.JosmAction;
+import org.openstreetmap.josm.command.AddCommand;
+import org.openstreetmap.josm.command.Command;
+import org.openstreetmap.josm.command.SequenceCommand;
+import org.openstreetmap.josm.data.UndoRedoHandler;
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.gui.util.GuiHelper;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * Action for capturing PGV tape.
+ */
+public class CSVPGVTapeCaptureAction extends JosmAction {
+
+    /**
+     * Constructs a new {@code CSVPGVTapeCaptureAction}.
+     */
+    public CSVPGVTapeCaptureAction() {
+        super("Capture PGV Tape", "mapmode/amrgoalaction", "Capture PGV Tape",
+                null, false);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        var transformer = new PointTransformer();
+        var ds = getLayerManager().getEditDataSet();
+        if (!transformer.setupFromDataSet(ds))
+            return;
+        var dialog = new CSVFileDialog();
+        var ret = dialog.showOpenDialog(MainApplication.getMainFrame());
+        if (ret == CSVFileDialog.APPROVE_OPTION) {
+            var file = dialog.getSelectedFile();
+            var data = loadCSVFile(file);
+            if (!data.isEmpty()) {
+                var agv_node_id = ToolsPlugin.getMaxId(ds.getNodes(), "agv_node_id");
+                var cmds = new LinkedList<Command>();
+                for (var d : data) {
+                    var ne0 = transformer.imageXYtoEastNorth(d.start_x, d.start_y);
+                    var ne1 = transformer.imageXYtoEastNorth(d.end_x, d.end_y);
+                    var nodes = new Node[]{
+                        new Node(ne0),
+                        new Node(ne1)
+                    };
+                    nodes[0].put("agv_node_id", Integer.toString(++agv_node_id));
+                    nodes[0].put("X_image", String.valueOf(d.start_x));
+                    nodes[0].put("Y_image", String.valueOf(d.start_y));
+                    nodes[1].put("agv_node_id", Integer.toString(++agv_node_id));
+                    nodes[1].put("X_image", String.valueOf(d.end_x));
+                    nodes[1].put("Y_image", String.valueOf(d.end_y));
+                    var way = new Way();
+                    way.addNode(nodes[0]);
+                    way.addNode(nodes[1]);
+                    way.put("line_info", "agv_pose");
+                    way.put("agv_line_start_offset", String.valueOf(d.start_pgv));
+                    way.put("agv_line_end_offset", String.valueOf(d.end_pgv));
+                    cmds.add(new AddCommand(ds, nodes[0]));
+                    cmds.add(new AddCommand(ds, nodes[1]));
+                    cmds.add(new AddCommand(ds, way));
+                }
+                UndoRedoHandler.getInstance().add(new SequenceCommand("Capture PGV Tape", cmds));
+            }
+        }
+    }
+
+    @Override
+    protected void updateEnabledState() {
+        var ds = getLayerManager().getEditDataSet();
+        setEnabled(ds != null && PointTransformer.hasTransformMatrix(ds));
+    }
+
+    /**
+     * Loads the CSV file.
+     * @param file the file
+     * @return the collection of CSV data
+     */
+    private Collection<PGVTapeData> loadCSVFile(File file) {
+        var path = file.toPath();
+        var data = new ArrayList<PGVTapeData>();
+        try {
+            var lines = Files.readAllLines(path);
+            lines.remove(0);
+            lines.forEach(line -> {
+                var parts = line.split(",");
+                if (parts.length >= 6) {
+                    var d = new PGVTapeData();
+                    d.start_x = Double.parseDouble(parts[0]);
+                    d.start_y = Double.parseDouble(parts[1]);
+                    d.start_pgv = Double.parseDouble(parts[2]);
+                    d.end_x = Double.parseDouble(parts[3]);
+                    d.end_y = Double.parseDouble(parts[4]);
+                    d.end_pgv = Double.parseDouble(parts[5]);
+                    data.add(d);
+                }
+            });
+        } catch (Exception ex) {
+            var notification = new Notification("Error reading CSV file.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+        }
+        if (data.isEmpty()) {
+            var notification = new Notification("No data found.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+        }
+        return data;
+    }
+
+    /**
+     * CSV data for PGV tape.
+     */
+    private static class PGVTapeData {
+
+        /**
+         * Start X coordinate.
+         */
+        double start_x;
+
+        /**
+         * Start Y coordinate.
+         */
+        double start_y;
+
+        /**
+         * Start PGV value.
+         */
+        double start_pgv;
+
+        /**
+         * End X coordinate.
+         */
+        double end_x;
+
+        /**
+         * End Y coordinate.
+         */
+        double end_y;
+
+        /**
+         * End PGV value.
+         */
+        double end_pgv;
+
+        /**
+         * Constructs a new {@code PGVTapeData}.
+         */
+        PGVTapeData() {
+            start_x = 0.0;
+            start_y = 0.0;
+            start_pgv = 0.0;
+            end_x = 0.0;
+            end_y = 0.0;
+            end_pgv = 0.0;
+        }
+    }
+
+}

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/PointTransformer.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/PointTransformer.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ * License: GPL. For details, see LICENSE file.
+ */
+
+package org.openstreetmap.josm.plugins.lexxpluss;
+
+import java.awt.geom.AffineTransform;
+import java.util.stream.Collectors;
+import org.openstreetmap.josm.data.coor.EastNorth;
+import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.gui.util.GuiHelper;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+/**
+ * Transforms matrix for LexxPluss.
+ */
+class PointTransformer {
+
+    /**
+     * The transform matrix.
+     */
+    private AffineTransform transform;
+
+    /**
+     * The view center longitude.
+     */
+    private double view_center_lon;
+
+    /**
+     * The view center latitude.
+     */
+    private double view_center_lat;
+
+    /**
+     * The pixel per east-north x.
+     */
+    private double pixel_per_en_x;
+
+    /**
+     * The pixel per east-north y.
+     */
+    private double pixel_per_en_y;
+
+    /**
+     * The picture offset x.
+     */
+    private double pic_offset_x;
+
+    /**
+     * The picture offset y.
+     */
+    private double pic_offset_y;
+
+    /**
+     * The scale x.
+     */
+    private double scaleX;
+
+    /**
+     * The scale y.
+     */
+    private double scaleY;
+
+    /**
+     * The half height.
+     */
+    private double hh;
+
+    /**
+     * The half width.
+     */
+    private double hw;
+
+    /**
+     * Constructs a new {@code PointTransformer}.
+     */
+    PointTransformer() {
+        transform = null;
+        view_center_lon = 0.0;
+        view_center_lat = 0.0;
+        pixel_per_en_x = -1.0;
+        pixel_per_en_y = -1.0;
+        pic_offset_x = 0.0;
+        pic_offset_y = 0.0;
+        scaleX = 0.0;
+        scaleY = 0.0;
+        hh = 0.0;
+        hw = 0.0;
+    }
+
+    /**
+     * Sets up the transform matrix from the given data set.
+     *
+     * @param dataSet the data set
+     * @return {@code true} if the setup was successful, {@code false} otherwise
+     */
+    boolean setupFromDataSet(DataSet dataSet) {
+        var way = getTransformMatrixWay(dataSet);
+        if (way == null) {
+            var notification = new Notification("No ways with transform matrix found.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+            return false;
+        }
+        var matrix = new double[6];
+        try {
+            matrix[0] = Double.parseDouble(way.get("m0"));
+            matrix[1] = Double.parseDouble(way.get("m1"));
+            matrix[2] = Double.parseDouble(way.get("m2"));
+            matrix[3] = Double.parseDouble(way.get("m3"));
+            matrix[4] = Double.parseDouble(way.get("m4"));
+            matrix[5] = Double.parseDouble(way.get("m5"));
+            view_center_lon = Double.parseDouble(way.get("view_center_lon"));
+            view_center_lat = Double.parseDouble(way.get("view_center_lat"));
+            pixel_per_en_x = Double.parseDouble(way.get("pixel_per_en_x"));
+            pixel_per_en_y = Double.parseDouble(way.get("pixel_per_en_y"));
+            pic_offset_x = Double.parseDouble(way.get("pic_offset_x"));
+            pic_offset_y = Double.parseDouble(way.get("pic_offset_y"));
+            scaleX = Double.parseDouble(way.get("scaleX"));
+            scaleY = Double.parseDouble(way.get("scaleY"));
+            hw = Double.parseDouble(way.get("hw"));
+            hh = Double.parseDouble(way.get("hh"));
+        } catch (Exception ex) {
+            var notification = new Notification("Error parsing transform matrix.")
+                    .setIcon(ImageProvider.get("data/error"));
+            GuiHelper.runInEDT(notification::show);
+            return false;
+        }
+        transform = new AffineTransform(matrix);
+        return true;
+    }
+
+    /**
+     * Transforms the given image coordinates to east-north coordinates.
+     *
+     * @param x the image x coordinate
+     * @param y the image y coordinate
+     * @return the east-north coordinates
+     */
+    EastNorth imageXYtoEastNorth(double x, double y) {
+        var in_point = new double[]{
+                (x - hw) / scaleX + pic_offset_x / transform.getScaleX(),
+                (y - hh) / scaleY + pic_offset_y / transform.getScaleY()
+        };
+        var cvt_point = new double[2];
+        transform.transform(in_point, 0, cvt_point, 0, 1);
+        var east = (cvt_point[0] / pixel_per_en_x) + view_center_lon;
+        var north = view_center_lat - (cvt_point[1] / pixel_per_en_y);
+        var pos = new EastNorth(east, north);
+        return pos;
+    }
+
+    /**
+     * Gets the way with the transform matrix.
+     * @param dataSet the data set
+     * @return the way with the transform matrix
+     */
+    static Way getTransformMatrixWay(DataSet dataSet) {
+        var ways = dataSet.getWays().stream()
+                .filter(w -> w.hasKey("transform matrix"))
+                .collect(Collectors.toList());
+        return ways.isEmpty() ? null : ways.get(0);
+    }
+
+    /**
+     * Checks if the data set has a transform matrix.
+     * @param dataSet the data set
+     * @return {@code true} if the data set has a transform matrix, {@code false} otherwise
+     */
+    static boolean hasTransformMatrix(DataSet dataSet) {
+        return getTransformMatrixWay(dataSet) != null;
+    }
+}

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/ToolsPlugin.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/ToolsPlugin.java
@@ -66,6 +66,8 @@ public class ToolsPlugin extends Plugin {
         MainMenu.add(moreMenu, new SyncAreaAction());
         MainMenu.add(moreMenu, new SafetyAreaAction());
         MainMenu.add(moreMenu, new NonStopAreaAction());
+        MainMenu.add(moreMenu, new CSVAMRGoalCaptureAction());
+        MainMenu.add(moreMenu, new CSVPGVTapeCaptureAction());
         OsmValidator.addTest(CustomTagTest.class);
     }
 


### PR DESCRIPTION
Introduce actions for capturing AMR goals and PGV tapes from CSV files. Implement a point transformer for coordinate conversion. Update the plugin to include new actions in the menu.

This function is only valid when an osm file containing coordinate transformation data is opened.

<img width="1212" alt="capture" src="https://github.com/user-attachments/assets/87cf1e44-fa62-4ad0-acdf-358fa3c85ded">

