### PR TITLE
refactor: Remove validation check for area_name tag's naming conventions

### DIFF
--- a/lexxpluss_tools/build.xml
+++ b/lexxpluss_tools/build.xml
@@ -7,7 +7,7 @@
     <property name="java.lang.version" value="11"/>
     <property name="commit.message" value="Commit message"/>
     <property name="plugin.main.version" value="19000"/>
-    <property name="plugin.version" value="1.6.0"/>
+    <property name="plugin.version" value="1.6.1"/>
     <property name="plugin.canloadatruntime" value="true"/>
     <property name="plugin.author" value="LexxPluss"/>
     <property name="plugin.class" value="org.openstreetmap.josm.plugins.lexxpluss.ToolsPlugin"/>

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CustomTagTest.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CustomTagTest.java
@@ -152,9 +152,6 @@ public class CustomTagTest extends Test {
             String intValue = null;
             if (intTags.contains(k)) {
                 intValue = value;
-            } else if (k.equals("area_name") &&
-                    (value.startsWith("park") || value.startsWith("sync"))) {
-                intValue = value.substring(4);
             }
             if (intValue != null) {
                 try {
@@ -197,14 +194,6 @@ public class CustomTagTest extends Test {
             var valueSet = tagMap.get(k);
             if (valueSet != null && !valueSet.contains(primitive.get(k)))
                 addError(primitive, 6002, "Invalid tag value:" + k + "=" + primitive.get(k));
-            if (k.equals("area_name")) {
-                var value = primitive.get(k);
-                if (value != null) {
-                    if (!value.equals("warning") && !value.equals("no stop") &&
-                            !value.startsWith("park") && !value.startsWith("sync"))
-                        addError(primitive, 6002, "Invalid tag value:" + k + "=" + value);
-                }
-            }
         });
     }
 


### PR DESCRIPTION
In response to [IOP-1889](https://lexxpluss.atlassian.net/browse/IOP-1889), this PR removes the validation check for the `area_name` tag's naming convention.

The decision is based on the following:
- The naming convention is not standardized across the team.
- The current naming has no impact on AMR behavior or movement.
- Treating this as an error is misleading and unnecessary.

I have tested the plugin locally and confirmed that it functions as expected after this change.

**Before (tested with `osaka.osm`)**
- Total number of errors: 257
- Number of errors regarding `area_name`: 63

![Screenshot from 2025-05-23 10-26-18](https://github.com/user-attachments/assets/5b5629ae-b358-4d71-a382-452665b68ae3)


**After (tested with `osaka.osm`)**
- Total number of errors: 194
- Number of errors regarding `area_name`: 0

![Screenshot from 2025-05-23 10-25-01](https://github.com/user-attachments/assets/7a152769-6430-4ba7-badc-8c4c2abcc338)



[IOP-1889]: https://lexxpluss.atlassian.net/browse/IOP-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ