### PR TITLE
Fix: IOP-2536 Potential crash due to lack Latitude info 

### DIFF
--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CoordChangeListenerPlugin.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CoordChangeListenerPlugin.java
@@ -204,7 +204,10 @@ public class CoordChangeListenerPlugin implements DataSetListener {
     }
 
     private void performCoordinateUpdate(Node node) {
-//        System.out.println("Node shall be moved to map coords: " + Double.toString(finalLatLon.getX()) + ", " + Double.toString(finalLatLon.getY()));
+        if (this.finalLatLon == null) {
+            return;
+        }
+        System.out.println("Node shall be moved to map coords: " + Double.toString(finalLatLon.getX()) + ", " + Double.toString(finalLatLon.getY()));
         UndoRedoHandler.getInstance().add(new MoveCommand(node, this.finalLatLon));
     }
 

--- a/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CoordChangeListenerPlugin.java
+++ b/lexxpluss_tools/src/org/openstreetmap/josm/plugins/lexxpluss/CoordChangeListenerPlugin.java
@@ -204,7 +204,7 @@ public class CoordChangeListenerPlugin implements DataSetListener {
     }
 
     private void performCoordinateUpdate(Node node) {
-        System.out.println("Node shall be moved to map coords: " + Double.toString(finalLatLon.getX()) + ", " + Double.toString(finalLatLon.getY()));
+//        System.out.println("Node shall be moved to map coords: " + Double.toString(finalLatLon.getX()) + ", " + Double.toString(finalLatLon.getY()));
         UndoRedoHandler.getInstance().add(new MoveCommand(node, this.finalLatLon));
     }
 


### PR DESCRIPTION
What happened:
- when copy paste an existing LexxPluss Way or create a LexxPluss Way, the `finalLatLon.getX()` and `finalLatLon.getY()` return Null when called. And cause crash.

Fix:
Comment out this println line seem solved the problem during testing using JOSM to make map. 
As end user do not have access to system out during operating JOSM anyway, it is safe to comment out this line
 

https://josm.openstreetmap.de/doc/org/openstreetmap/josm/data/coor/LatLon.html